### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://khanasif1.visualstudio.com/1fdcce7f-0348-4565-98ee-d65015cc9fe1/10287700-dff3-4f1f-beb8-bc916b3ecba4/_apis/work/boardbadge/d32c7026-e3fd-4980-a9f4-ff3ee955990b)](https://khanasif1.visualstudio.com/1fdcce7f-0348-4565-98ee-d65015cc9fe1/_boards/board/t/10287700-dff3-4f1f-beb8-bc916b3ecba4/Microsoft.RequirementCategory)
 # action_runner


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#52](https://khanasif1.visualstudio.com/1fdcce7f-0348-4565-98ee-d65015cc9fe1/_workitems/edit/52). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.